### PR TITLE
feat(doom-emacs): use a ~font-family~ variable in config.el

### DIFF
--- a/doom-emacs/.doom.d/config.el
+++ b/doom-emacs/.doom.d/config.el
@@ -21,9 +21,10 @@
 ;; font string. You generally only need these two:
 ;; (setq doom-font (font-spec :family "monospace" :size 12 :weight 'semi-light)
 ;;       doom-variable-pitch-font (font-spec :family "sans" :size 13))
-(setq doom-font (font-spec :family "FuraCode Nerd Font" :size 32)
-      doom-variable-pitch-font (font-spec :family "FiraCode Nerd Font" :size 32)
-      doom-big-font (font-spec :family "FuraCode Nerd Font" :size 64))
+(setq font-family (if (member system-type '(cygwin ms-dos windows-nt)) "SauceCodePro NF" "SauceCodePro Nerd Font"))
+(setq doom-font (font-spec :family font-family :size 32)
+      doom-variable-pitch-font (font-spec :family font-family :size 32)
+      doom-big-font (font-spec :family font-family :size 64))
 
 ;; There are two ways to load a theme. Both assume the theme is installed and
 ;; available. You can either set `doom-theme' or manually load a theme with the
@@ -109,7 +110,7 @@
   ;; English font
   (if (display-graphic-p)
       (progn
-        (set-face-attribute 'default nil :font (format "%s:pixelsize=%d" "FuraCode Nerd Font" 32))
+        (set-face-attribute 'default nil :font (format "%s:pixelsize=%d" font-family 32))
         ;; Chinese font
         (dolist (charset '(kana han symbol cjk-misc bopomofo))
           (set-fontset-font (frame-parameter nil 'font)


### PR DESCRIPTION
support cross platform