### PR TITLE
feat(doom-emacs): enable breaking long lines within code blocks

### DIFF
--- a/doom-emacs/.doom.d/config.el
+++ b/doom-emacs/.doom.d/config.el
@@ -174,6 +174,9 @@
   :config
   (add-to-list 'org-latex-packages-alist '("" "minted"))
   (setq org-latex-listings 'minted)
+  ;; Break long lines in code blocks
+  (setq org-latex-minted-options '(("breaklines" "true")
+                                   ("breakanywhere" "true")))
   (setq org-latex-pdf-process
         '("pdflatex -shell-escape -interaction nonstopmode -output-directory %o %f"
           "pdflatex -shell-escape -interaction nonstopmode -output-directory %o %f"


### PR DESCRIPTION
when export to PDF files